### PR TITLE
fix wrong url to python website

### DIFF
--- a/_topic/python.markdown
+++ b/_topic/python.markdown
@@ -1,7 +1,7 @@
 ---
 layout: topic
 title: "Python"
-website: "https://pythonlang.org"
+website: "https://python.org"
 snipper: "Python is a programming languge known for its simplicity and wide range of uses."
 ---
 


### PR DESCRIPTION
Pythonlang.org is a fake website, the official Python website is python.org